### PR TITLE
Refine scheduler performance and caching

### DIFF
--- a/scheduler-playground/scheduler/scheduler/common/settings.py
+++ b/scheduler-playground/scheduler/scheduler/common/settings.py
@@ -7,8 +7,26 @@ from functools import lru_cache
 
 
 @lru_cache(maxsize=None)
+def allow_naive_scheduler() -> bool:
+    """Return True when the legacy ``naive`` scheduler path is explicitly allowed."""
+
+    return os.getenv("ZENTIO_ALLOW_NAIVE", "0").lower() in {"1", "true", "yes", "on"}
+
+
+@lru_cache(maxsize=None)
 def get_scheduler_mode() -> str:
-    return os.getenv("ZENTIO_SCHEDULER_MODE", "naive").lower()
+    """Return the requested scheduler implementation.
+
+    The topological scheduler is the default.  The legacy ``naive`` mode can only be
+    re-enabled by setting ``ZENTIO_ALLOW_NAIVE`` in addition to
+    ``ZENTIO_SCHEDULER_MODE=naive`` which prevents accidental regressions when the
+    slow path is left configured in production or CI environments.
+    """
+
+    requested = os.getenv("ZENTIO_SCHEDULER_MODE", "topo").lower()
+    if requested == "naive" and not allow_naive_scheduler():
+        return "topo"
+    return requested
 
 
 @lru_cache(maxsize=None)
@@ -26,9 +44,18 @@ def debug_print_enabled() -> bool:
     return os.getenv("ZENTIO_DEBUG_PRINT", "0") in {"1", "true", "yes", "on"}
 
 
+@lru_cache(maxsize=None)
+def get_log_verbosity() -> str:
+    """Return the configured log verbosity for playground runs."""
+
+    return os.getenv("ZENTIO_LOG_VERBOSITY", "info").lower()
+
+
 __all__ = [
+    "allow_naive_scheduler",
     "get_scheduler_mode",
     "get_slot_search_mode",
     "use_resource_manager_clone",
     "debug_print_enabled",
+    "get_log_verbosity",
 ]


### PR DESCRIPTION
## Summary
- default the scheduler to the topological implementation with cached per-run operation schedulers and precomputed dependency metadata
- add new environment flags for guarding the naive path and tuning log verbosity for profiling runs
- cache operator capability lookups and switch operator availability searches to interval boundary scans

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68e4364c01e0832a945f60abf5d6179f