### PR TITLE
Add profiling run summaries and benchmarking harness

### DIFF
--- a/scheduler-playground/scheduler/scheduler/common/console.py
+++ b/scheduler-playground/scheduler/scheduler/common/console.py
@@ -1,0 +1,64 @@
+"""Helpers for constructing Rich consoles with environment-driven verbosity."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+try:  # Rich is an optional dependency in some environments
+    from rich.console import Console
+except Exception:  # pragma: no cover - optional dependency
+    Console = None  # type: ignore
+
+from .settings import get_logging_verbosity
+
+_SILENT_KWARGS = {
+    "quiet": True,
+    "highlight": False,
+    "markup": False,
+    "emoji": False,
+    "color_system": None,
+    "soft_wrap": True,
+}
+
+_VERBOSE_KWARGS = {"soft_wrap": True}
+
+
+def get_console(level: Optional[str] = None, **kwargs: Any) -> "Console":
+    """Return a Rich ``Console`` configured for the requested verbosity.
+
+    The console respects ``ZENTIO_LOG_VERBOSITY`` so benchmarks and other
+    non-interactive tooling can disable expensive rich rendering when the
+    verbosity is set to ``warning``/``error``/``quiet``.
+
+    Args:
+        level: Optional verbosity override (``debug``/``info``/... ). When not
+            provided the value returned by :func:`get_logging_verbosity` is used.
+        **kwargs: Additional keyword arguments forwarded to ``Console``.
+
+    Returns:
+        A configured ``Console`` instance. When Rich is not installed a minimal
+        stub that mimics the ``Console`` API is returned.
+    """
+
+    verbosity = (level or get_logging_verbosity()).lower()
+
+    # Rich is optional for some deployments; fall back to a lightweight stub
+    if Console is None:  # pragma: no cover - executed when Rich is unavailable
+        return _FallbackConsole()
+
+    base_kwargs = _VERBOSE_KWARGS if verbosity in {"debug", "info"} else _SILENT_KWARGS
+    config = {**base_kwargs, **kwargs}
+    return Console(**config)
+
+
+class _FallbackConsole:
+    """Fallback console used when Rich is not available."""
+
+    def print(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
+        print(*args, **kwargs)
+
+    def log(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
+        print(*args, **kwargs)
+
+
+__all__ = ["get_console"]

--- a/scheduler-playground/scheduler/scheduler/services/genetic_optimizer.py
+++ b/scheduler-playground/scheduler/scheduler/services/genetic_optimizer.py
@@ -32,6 +32,7 @@ from scheduler.models import (
 from scheduler.services.resource_manager import ResourceManager
 from scheduler.services.scheduler import SchedulerService
 from scheduler.utils.resource_logger import ResourceLogger
+from scheduler.common.console import get_console
 from scheduler.common.settings import (
     use_resource_manager_clone,
     debug_print_enabled,
@@ -244,9 +245,7 @@ class GeneticSchedulerOptimizer:
         # Debug: Print initial resource availability table before optimization
         if debug_print_enabled():
             try:
-                from rich.console import Console
-
-                console = Console()
+                console = get_console()
                 console.print("\n[bold cyan]Initial Resource Availability (GA)[/bold cyan]")
                 availability_table = ResourceLogger.initial_availability_table(
                     self.original_resource_manager.resources

--- a/scheduler-playground/scheduler/scheduler/services/run_processor.py
+++ b/scheduler-playground/scheduler/scheduler/services/run_processor.py
@@ -23,6 +23,7 @@ from scheduler.services.resource_manager import ResourceManager
 from scheduler.models import ManufacturingOrder, Resource
 from scheduler.common.settings import debug_print_enabled
 from utils.data_converters import convert_manufacturing_orders, convert_resources
+from scheduler.common.console import get_console
 
 logger = logging.getLogger(__name__)
 
@@ -185,10 +186,9 @@ class RunProcessor:
             return
         try:
             from datetime import datetime, timedelta
-            from rich.console import Console
             from scheduler.utils.resource_logger import ResourceLogger
 
-            console = Console()
+            console = get_console()
 
             logger.info("=" * 80)
             logger.info("🔍 RESOURCE AVAILABILITY ANALYSIS")

--- a/scheduler-playground/scheduler/scheduler/utils/genetic_algorithm_logger.py
+++ b/scheduler-playground/scheduler/scheduler/utils/genetic_algorithm_logger.py
@@ -1,12 +1,24 @@
 from typing import List, Dict, Tuple, Optional, TYPE_CHECKING
 from rich import box, table
-from rich.console import Console
 from rich.panel import Panel
 import logging
 import multiprocessing as mp
 
 from scheduler.models import Schedule, OperationNode, ManufacturingOrder
 from scheduler.utils.schedule_logger import ScheduleLogger
+from scheduler.common.console import get_console
+
+try:  # Rich console is optional when running in benchmark mode
+    from rich.console import Console
+except Exception:  # pragma: no cover - optional dependency
+    class Console:  # type: ignore[override]
+        """Minimal stub used when Rich isn't available."""
+
+        def print(self, *_args, **_kwargs) -> None:
+            return None
+
+        def log(self, *_args, **_kwargs) -> None:
+            return None
 
 if TYPE_CHECKING:
     from scheduler.services.genetic_optimizer import (
@@ -303,7 +315,7 @@ class GeneticAlgorithmLogger:
     ) -> None:
         """Print a detailed table showing the evolution across generations."""
         if console is None:
-            console = Console()
+            console = get_console()
 
         try:
             from rich.table import Table

--- a/scheduler-playground/scheduler/scheduler/utils/resource_logger.py
+++ b/scheduler-playground/scheduler/scheduler/utils/resource_logger.py
@@ -1,9 +1,38 @@
-from typing import List
-from rich import box, table
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+try:
+    from rich import box, table
+except Exception:  # pragma: no cover - optional dependency fallback
+    class _NullTable:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_column(self, *args, **kwargs):
+            return None
+
+        def add_row(self, *args, **kwargs):
+            return None
+
+        def add_section(self, *args, **kwargs):
+            return None
+
+    class _Box:
+        ROUNDED = None
+        SIMPLE = None
+
+    class _TableModule:
+        Table = _NullTable
+
+    box = _Box()  # type: ignore
+    table = _TableModule()  # type: ignore
 
 from scheduler.models import Resource, ResourceType
-from scheduler.services.resource_manager import ResourceManager
 from scheduler.utils.utils import style_datetime, style_duration
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scheduler.services.resource_manager import ResourceManager
 
 RESOURCE_COLORS = {
     ResourceType.MACHINE: "cyan",

--- a/scheduler-playground/scheduler/scheduler/utils/schedule_logger.py
+++ b/scheduler-playground/scheduler/scheduler/utils/schedule_logger.py
@@ -1,5 +1,29 @@
 from typing import Optional
-from rich import box, console as rich_console, table
+try:
+    from rich import box, table
+except Exception:  # pragma: no cover - optional dependency fallback
+    class _NullTable:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_column(self, *args, **kwargs):
+            return None
+
+        def add_row(self, *args, **kwargs):
+            return None
+
+        def add_section(self, *args, **kwargs):
+            return None
+
+    class _Box:
+        ROUNDED = None
+        SIMPLE = None
+
+    class _TableModule:
+        Table = _NullTable
+
+    box = _Box()  # type: ignore
+    table = _TableModule()  # type: ignore
 
 from scheduler.models import (
     Resource,
@@ -9,6 +33,7 @@ from scheduler.models import (
     DropReason,
 )
 from scheduler.utils.utils import style_datetime
+from scheduler.common.console import get_console
 
 PHASE_COLORS = {
     TaskPhase.SETUP: "yellow",
@@ -238,7 +263,7 @@ class ScheduleLogger:
 
     @staticmethod
     def print(schedule: Schedule, title: Optional[str] = None) -> None:
-        console = rich_console.Console()
+        console = get_console()
         # console.print(ScheduleLogger.schedule_table(schedule, title=title))
         # console.print(ScheduleLogger.schedule_summary_table(schedule))
 

--- a/scheduler-playground/scheduler/tests/__main__.py
+++ b/scheduler-playground/scheduler/tests/__main__.py
@@ -1,8 +1,9 @@
 from tests.test_1 import test_1
 
 from rich.console import Console
+from scheduler.common.console import get_console
 
 
 if __name__ == "__main__":
-    console = Console()
+    console = get_console()
     test_1(console)

--- a/scheduler-playground/scheduler/tests/fixtures/__init__.py
+++ b/scheduler-playground/scheduler/tests/fixtures/__init__.py
@@ -1,0 +1,15 @@
+"""Helper fixtures for constructing large deterministic scheduler workloads."""
+
+from .synthetic_workloads import (
+    generate_synthetic_manufacturing_orders,
+    generate_synthetic_operations,
+    generate_synthetic_resources,
+    generate_workload,
+)
+
+__all__ = [
+    "generate_synthetic_manufacturing_orders",
+    "generate_synthetic_operations",
+    "generate_synthetic_resources",
+    "generate_workload",
+]

--- a/scheduler-playground/scheduler/tests/fixtures/synthetic_workloads.py
+++ b/scheduler-playground/scheduler/tests/fixtures/synthetic_workloads.py
@@ -1,0 +1,259 @@
+"""Synthetic workload generators for stress testing scheduler algorithms."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, List, Sequence, Tuple
+
+from scheduler.models import (
+    ManufacturingOrder,
+    OperationGraph,
+    OperationNode,
+    OperatorRequirement,
+    Resource,
+    ResourceAvailability,
+    ResourceCapability,
+    ResourceType,
+    TaskPhase,
+)
+
+
+_DEFAULT_START = datetime(2024, 1, 1, 8, 0, 0)
+
+
+def _build_availabilities(
+    count: int,
+    *,
+    start: datetime,
+    window_hours: int,
+    gap_hours: int,
+) -> List[ResourceAvailability]:
+    availabilities: List[ResourceAvailability] = []
+    for index in range(count):
+        window_start = start + timedelta(days=index, hours=(index % 3) * gap_hours)
+        window_end = window_start + timedelta(hours=window_hours)
+        availabilities.append(
+            ResourceAvailability(
+                start_datetime=window_start,
+                end_datetime=window_end,
+                effort=1.0,
+            )
+        )
+    return availabilities
+
+
+def generate_synthetic_manufacturing_orders(
+    mo_count: int = 200,
+    operations_per_mo: int = 6,
+    *,
+    start: datetime | None = None,
+) -> List[ManufacturingOrder]:
+    """Create deterministic manufacturing orders with consistent dependency chains."""
+
+    base_start = (start or _DEFAULT_START).replace(minute=0, second=0, microsecond=0)
+    manufacturing_orders: List[ManufacturingOrder] = []
+
+    for mo_index in range(mo_count):
+        operations: List[OperationNode] = []
+        previous_operation: OperationNode | None = None
+
+        for step in range(operations_per_mo):
+            op_id = f"op-{mo_index:04d}-{step:02d}"
+            durations = {
+                TaskPhase.SETUP: timedelta(minutes=15 + (step % 3) * 5),
+                TaskPhase.CORE_OPERATION: timedelta(minutes=60 + (step % 4) * 10),
+                TaskPhase.CLEANUP: timedelta(minutes=10),
+            }
+            operator_requirements = {
+                TaskPhase.CORE_OPERATION: [
+                    OperatorRequirement(
+                        phase=TaskPhase.CORE_OPERATION,
+                        operator_count=1 + (step % 2),
+                        effort=1.0,
+                    )
+                ]
+            }
+
+            operation = OperationNode(
+                operation_id=op_id,
+                operation_name=f"Synthetic Operation {mo_index:04d}-{step:02d}",
+                durations=durations,
+                quantity=1 + (step % 3),
+                dependencies=[previous_operation] if previous_operation else [],
+                operator_requirements=operator_requirements,
+                manufacturing_order_id=f"MO-{mo_index:04d}",
+                manufacturing_order_name=f"Synthetic MO {mo_index:04d}",
+                article_id=f"ART-{mo_index:04d}",
+                article_name=f"Article {mo_index:04d}",
+            )
+            operations.append(operation)
+            previous_operation = operation
+
+        operations_graph = OperationGraph(nodes=operations)
+        required_date = base_start + timedelta(days=mo_index % 30)
+        manufacturing_orders.append(
+            ManufacturingOrder(
+                manufacturing_order_id=f"MO-{mo_index:04d}",
+                manufacturing_order_name=f"Synthetic MO {mo_index:04d}",
+                article_id=f"ART-{mo_index:04d}",
+                article_name=f"Article {mo_index:04d}",
+                quantity=1 + (mo_index % 5),
+                operations_graph=operations_graph,
+                required_by_date=required_date,
+            )
+        )
+
+    return manufacturing_orders
+
+
+def generate_synthetic_operations(
+    manufacturing_orders: Sequence[ManufacturingOrder],
+) -> List[OperationNode]:
+    """Flatten manufacturing orders into a single operations list."""
+
+    operations: List[OperationNode] = []
+    for mo in manufacturing_orders:
+        if mo.operations_graph and mo.operations_graph.nodes:
+            operations.extend(mo.operations_graph.nodes)
+    return operations
+
+
+def _build_capability_assignments(
+    item_ids: Sequence[str],
+    resource_slots: int,
+    fan_out: int,
+) -> List[List[str]]:
+    assignments: List[List[str]] = [[] for _ in range(resource_slots)]
+    if not item_ids:
+        return assignments
+
+    for index, item_id in enumerate(item_ids):
+        for offset in range(max(1, fan_out)):
+            slot = (index + offset) % resource_slots
+            assignments[slot].append(item_id)
+    return assignments
+
+
+def generate_synthetic_resources(
+    operation_ids: Iterable[str],
+    *,
+    machine_count: int = 80,
+    operator_count: int = 120,
+    availability_days: int = 14,
+    start: datetime | None = None,
+) -> List[Resource]:
+    """Generate large synthetic resource pools covering all provided operations."""
+
+    op_ids = sorted(set(operation_ids))
+    base_start = (start or _DEFAULT_START).replace(minute=0, second=0, microsecond=0)
+
+    machine_assignments = _build_capability_assignments(op_ids, machine_count, fan_out=max(1, machine_count // 8))
+    operator_assignments = _build_capability_assignments(op_ids, operator_count, fan_out=max(1, operator_count // 10))
+
+    resources: List[Resource] = []
+
+    for machine_index in range(machine_count):
+        capabilities = [
+            ResourceCapability(
+                resource_type=ResourceType.MACHINE,
+                phase=TaskPhase.CORE_OPERATION,
+                operation_id=operation_id,
+            )
+            for operation_id in machine_assignments[machine_index]
+        ]
+        if not capabilities:
+            # Ensure every machine can handle at least one operation
+            capabilities.append(
+                ResourceCapability(
+                    resource_type=ResourceType.MACHINE,
+                    phase=TaskPhase.CORE_OPERATION,
+                    operation_id=op_ids[machine_index % len(op_ids)] if op_ids else "fallback",
+                )
+            )
+
+        availabilities = _build_availabilities(
+            availability_days,
+            start=base_start,
+            window_hours=10,
+            gap_hours=2,
+        )
+        resources.append(
+            Resource(
+                resource_id=f"machine-{machine_index:04d}",
+                resource_type=ResourceType.MACHINE,
+                resource_name=f"Machine {machine_index:04d}",
+                resource_capabilities=capabilities,
+                availabilities=availabilities,
+            )
+        )
+
+    for operator_index in range(operator_count):
+        capabilities = [
+            ResourceCapability(
+                resource_type=ResourceType.OPERATOR,
+                phase=TaskPhase.CORE_OPERATION,
+                operation_id=operation_id,
+            )
+            for operation_id in operator_assignments[operator_index]
+        ]
+        if not capabilities:
+            capabilities.append(
+                ResourceCapability(
+                    resource_type=ResourceType.OPERATOR,
+                    phase=TaskPhase.CORE_OPERATION,
+                    operation_id=op_ids[operator_index % len(op_ids)] if op_ids else "fallback",
+                )
+            )
+
+        availabilities = _build_availabilities(
+            availability_days,
+            start=base_start,
+            window_hours=8,
+            gap_hours=1,
+        )
+        resources.append(
+            Resource(
+                resource_id=f"operator-{operator_index:04d}",
+                resource_type=ResourceType.OPERATOR,
+                resource_name=f"Operator {operator_index:04d}",
+                resource_capabilities=capabilities,
+                availabilities=availabilities,
+            )
+        )
+
+    return resources
+
+
+def generate_workload(
+    *,
+    mo_count: int = 200,
+    operations_per_mo: int = 6,
+    machine_count: int = 80,
+    operator_count: int = 120,
+    availability_days: int = 14,
+    start: datetime | None = None,
+) -> Tuple[List[ManufacturingOrder], List[Resource], List[OperationNode]]:
+    """Convenience helper returning manufacturing orders, resources and operations."""
+
+    manufacturing_orders = generate_synthetic_manufacturing_orders(
+        mo_count,
+        operations_per_mo,
+        start=start,
+    )
+    operations = generate_synthetic_operations(manufacturing_orders)
+    resources = generate_synthetic_resources(
+        [operation.operation_id for operation in operations],
+        machine_count=machine_count,
+        operator_count=operator_count,
+        availability_days=availability_days,
+        start=start,
+    )
+    return manufacturing_orders, resources, operations
+
+
+__all__ = [
+    "generate_synthetic_manufacturing_orders",
+    "generate_synthetic_operations",
+    "generate_synthetic_resources",
+    "generate_workload",
+]

--- a/scheduler-playground/scheduler/tests/test_1.py
+++ b/scheduler-playground/scheduler/tests/test_1.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from copy import deepcopy
 
 from rich.console import Console
+from scheduler.common.console import get_console
 
 from scheduler.models import (
     TaskPhase,

--- a/scheduler-playground/scheduler/tests/test_genetic.py
+++ b/scheduler-playground/scheduler/tests/test_genetic.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from rich.console import Console
+from scheduler.common.console import get_console
 
 from scheduler.models import ManufacturingOrder, Priority
 from scheduler.services.resource_manager import ResourceManager
@@ -150,5 +151,5 @@ def test_genetic(console: Console):
 
 
 if __name__ == "__main__":
-    console = Console()
+    console = get_console()
     test_genetic(console)

--- a/scheduler-playground/scheduler/tests/test_genetic_2.py
+++ b/scheduler-playground/scheduler/tests/test_genetic_2.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from copy import deepcopy
 from rich.console import Console
+from scheduler.common.console import get_console
 
 from scheduler.models import ManufacturingOrder, Priority
 from scheduler.services.resource_manager import ResourceManager
@@ -369,5 +370,5 @@ def test_genetic_2(console: Console):
 
 
 if __name__ == "__main__":
-    console = Console()
+    console = get_console()
     test_genetic_2(console)

--- a/scheduler-playground/scheduler/tests/test_genetic_real.py
+++ b/scheduler-playground/scheduler/tests/test_genetic_real.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import argparse
 
 from rich.console import Console
+from scheduler.common.console import get_console
 
 # Add the project root to Python path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -263,7 +264,7 @@ if __name__ == "__main__":
         for k, v in vars(args).items()
         if v is not None and k not in {"show_schedule", "no_evolution_logging"}
     }
-    console = Console()
+    console = get_console()
     test_genetic_real(
         console,
         config_overrides=overrides,

--- a/scheduler-playground/scheduler/tools/benchmark.py
+++ b/scheduler-playground/scheduler/tools/benchmark.py
@@ -1,0 +1,128 @@
+"""Deterministic benchmarking harness for scheduler conversions and pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+# Ensure profiling is enabled before importing profiling helpers
+os.environ.setdefault("ZENTIO_PROFILE", os.getenv("ZENTIO_PROFILE", "1"))
+
+from scheduler.common.profiling import (  # noqa: E402  (import after env setup)
+    Profiler,
+    profile_section,
+    profile_enabled,
+    reset_correlation_id,
+    set_correlation_id,
+)
+from scheduler.common.console import get_console  # noqa: E402
+from scheduler.services.resource_manager import ResourceManager  # noqa: E402
+from scheduler.services.scheduler import SchedulerService  # noqa: E402
+from utils.data_converters import (  # noqa: E402
+    convert_manufacturing_orders,
+    convert_resources,
+)
+
+
+def _load_dataset(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _run_iteration(data: Dict[str, Any], iteration: int) -> Dict[str, Any]:
+    token = set_correlation_id(f"benchmark-iter-{iteration:03d}")
+    try:
+        with profile_section("benchmark.convert_mos"):
+            manufacturing_orders = convert_manufacturing_orders(
+                data.get("manufacturing_orders") or data.get("manufacturingOrdersRequirements") or []
+            )
+        with profile_section("benchmark.convert_resources"):
+            resources = convert_resources(
+                data.get("resources") or data.get("availableResources") or []
+            )
+
+        operations: List[Any] = []
+        for manufacturing_order in manufacturing_orders:
+            if manufacturing_order.operations_graph and manufacturing_order.operations_graph.nodes:
+                operations.extend(manufacturing_order.operations_graph.nodes)
+
+        with profile_section("benchmark.resource_manager"):
+            resource_manager = ResourceManager(resources)
+
+        with profile_section("benchmark.schedule"):
+            schedule = SchedulerService.schedule(operations, resource_manager)
+
+        return {
+            "iteration": iteration,
+            "manufacturing_orders": len(manufacturing_orders),
+            "operations": len(operations),
+            "resources": len(resources),
+            "tasks": len(schedule.tasks),
+            "dropped_operations": len(schedule.dropped_operations or []),
+            "makespan": str(schedule.makespan) if schedule.makespan else None,
+        }
+    finally:
+        reset_correlation_id(token)
+
+
+def run_benchmark(dataset: Path, iterations: int) -> Dict[str, Any]:
+    data = _load_dataset(dataset)
+    profiler = Profiler.instance()
+    summary: List[Dict[str, Any]] = []
+
+    with profile_section("benchmark.total_run"):
+        for iteration in range(1, iterations + 1):
+            summary.append(_run_iteration(data, iteration))
+
+    if getattr(profiler, "enabled", False):
+        profiler.flush()
+
+    return {
+        "dataset": str(dataset),
+        "iterations": iterations,
+        "results": summary,
+        "profile_dir": str(Path(".profile").resolve()),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "data" / "real_combined.json",
+        help="Path to the dataset JSON file (defaults to bundled real_combined.json)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=3,
+        help="Number of benchmark iterations to execute",
+    )
+    args = parser.parse_args()
+
+    console = get_console()
+    result = run_benchmark(args.dataset, max(1, args.iterations))
+
+    console.print("[bold cyan]Scheduler benchmark summary[/bold cyan]")
+    console.print(json.dumps(result, indent=2))
+
+    if not profile_enabled():
+        console.print(
+            "[yellow]Warning:[/] Profiling artifacts were not generated because"
+            " ZENTIO_PROFILE was disabled."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- persist per-run profiling aggregates in both JSON and CSV formats so CI can track wall-clock trends
- introduce an environment-aware console helper and route scheduler logging through it to reduce noisy Rich output when benchmarks run in quiet mode
- add large synthetic workload fixtures and a deterministic benchmarking harness that exercises the converters-to-scheduler pipeline

## Testing
- python scheduler-playground/scheduler/tools/benchmark.py --iterations 1 --dataset scheduler-playground/data/real_combined.json

------
https://chatgpt.com/codex/tasks/task_e_68e4e6232de0832a9aa4b87eb1b131d6