### PR TITLE
Reuse cached OperationScheduler instances across scheduling runs

### DIFF
--- a/scheduler-playground/scheduler/scheduler/services/operation_scheduler.py
+++ b/scheduler-playground/scheduler/scheduler/services/operation_scheduler.py
@@ -36,6 +36,11 @@ class OperationScheduler:
         self._core_task_buffer: List[Task] = []
         self._idle_buffer: List[Idle] = []
 
+    def reset_run_state(self) -> None:
+        """Reset transient buffers while keeping cached data warm."""
+        self._core_task_buffer.clear()
+        self._idle_buffer.clear()
+
     @staticmethod
     def _get_phase_cache(operation: OperationNode) -> tuple[Tuple[TaskPhase, timedelta], ...]:
         cached = getattr(operation, "_cached_phase_sequence", None)


### PR DESCRIPTION
## Summary
- pool OperationScheduler instances in SchedulerService so scheduling runs reuse warm caches per resource manager
- add a reset_run_state helper to OperationScheduler to clear transient buffers between runs

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_e_68e4eb00aa64832ab6d7176e40e8b0ef